### PR TITLE
add meta tags & compressed banner img

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta description="Mobile Dev Month is a series of four meetups we're doing in the month of March, to explore how to build native mobile apps in Android, iOS and cross-platform apps using Ionic Framework and React Native. These will be full day meetups, with a teaching session in the monring that will include a walkthrough of how to build an example app in that platform. We'll then have a lunch break where all attendies can network, followed by an open house pair programming session..">
     <meta property="og:type" content="website"/>
     <meta property="og:title" content="Mobile Dev Month - Learn How to Build Mobile Apps">
-    <meta property="og:url" content="http://mobile-dev-month.surge.sh/">
+    <meta property="og:url" content="https://fcc-hyd.github.io/mobile-dev-month/">
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image" content="./img/phone.png">
     <meta property="og:site_name" content="Mobile Dev Month - FCC HYD">

--- a/meetup01/index.html
+++ b/meetup01/index.html
@@ -2,6 +2,14 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta description="In this meetup, we'll introduce you to Android Development, and walk you through building a simple todo app. Following that, we'll have a break for lunch where you can network with other developers.">
+  <meta property="og:type" content="website"/>
+  <meta property="og:title" content="Learn Android Development | Mobile Dev Month">
+  <meta property="og:url" content="https://fcc-hyd.github.io/mobile-dev-month/meetup01">
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image" content="../img/phone.png">
+  <meta property="og:site_name" content="Mobile Dev Month - FCC HYD">
+  <meta property="og:description" content="In this meetup, we'll introduce you to Android Development, and walk you through building a simple todo app. Following that, we'll have a break for lunch where you can network with other developers.">
   <title>Learn Android Development | Mobile Dev Month</title>
   <link rel="icon" type="image/png" href="../img/favicon.png">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">

--- a/meetup02/index.html
+++ b/meetup02/index.html
@@ -2,6 +2,14 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta description="In this meetup, we'll introduce you to iOS Development, by walking you through building a simple todo app. Following the teaching session, we'll have a break for lunch, where you can network with other developers.">
+    <meta property="og:type" content="website"/>
+    <meta property="og:title" content="Learn IOS Development | Mobile Dev Month">
+    <meta property="og:url" content="https://fcc-hyd.github.io/mobile-dev-month/meetup02">
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image" content="../img/phone.png">
+    <meta property="og:site_name" content="Mobile Dev Month - FCC HYD">
+    <meta property="og:description" content="In this meetup, we'll introduce you to iOS Development, by walking you through building a simple todo app. Following the teaching session, we'll have a break for lunch, where you can network with other developers.">
     <title>Learn iOS | Mobile Dev Month</title>
     <link rel="icon" type="image/png" href="../img/favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">

--- a/meetup03/index.html
+++ b/meetup03/index.html
@@ -2,6 +2,14 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta description="In this meetup, we'll introduce you to the Ionic Framework, and walk you through building a simple todo app. Following that, we'll have a break for lunch where you can network with other developers.">
+  <meta property="og:type" content="website"/>
+  <meta property="og:title" content="Learn Ionic Framework | Mobile Dev Month">
+  <meta property="og:url" content="https://fcc-hyd.github.io/mobile-dev-month/meetup03">
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image" content="../img/phone.png">
+  <meta property="og:site_name" content="Mobile Dev Month - FCC HYD">
+  <meta property="og:description" content="In this meetup, we'll introduce you to the Ionic Framework, and walk you through building a simple todo app. Following that, we'll have a break for lunch where you can network with other developers.">
   <title>Learn Ionic Framework | Mobile Dev Month</title>
   <link rel="icon" type="image/png" href="../img/favicon.png">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">

--- a/meetup04/index.html
+++ b/meetup04/index.html
@@ -2,6 +2,14 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta description="In this meetup, we'll introduce you to React Native, and walk you through building a simple todo app using it. Following that, we'll have a break for lunch where you can network with other developers.">
+    <meta property="og:type" content="website"/>
+    <meta property="og:title" content="Learn React Native | Mobile Dev Month">
+    <meta property="og:url" content="https://fcc-hyd.github.io/mobile-dev-month/meetup04">
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image" content="../img/phone.png">
+    <meta property="og:site_name" content="Mobile Dev Month - FCC HYD">
+    <meta property="og:description" content="In this meetup, we'll introduce you to React Native, and walk you through building a simple todo app using it. Following that, we'll have a break for lunch where you can network with other developers.">
     <title>Learn React Native | Mobile Dev Month</title>
     <link rel="icon" type="image/png" href="../img/favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">


### PR DESCRIPTION
- Fixes #3 
- Added meta tags to meetup pages
- Fix `og:url` to point to github page URL ( @duttakapil may be this could fix few issues/warnings mentioned here https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Ffcc-hyd.github.io%2Fmobile-dev-month%2F )